### PR TITLE
Update Hugo to 0.152.2 in CI workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3
         with:
-          hugo-version: "0.140.0"
+          hugo-version: "0.152.2"
 
       - name: Setup Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0


### PR DESCRIPTION
Updates the Hugo version in the GitHub Actions CI workflow from 0.140.0 to 0.152.2. This brings the CI environment to the latest stable release (October 2025) with important security fixes and CSS3 minification improvements.

**Changes:**
- Hugo version: 0.140.0 → 0.152.2