### PR TITLE
Convert light theme to Catppuccin Latte

### DIFF
--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -360,7 +360,7 @@
   }
 
   blockquote {
-    border-left: 2px solid #999;
+    border-left: 2px solid #9ca0b0;
     color: var(--heading-color);
     padding-left: 25px;
     padding-right: 15px;
@@ -383,7 +383,7 @@
   }
 
   ul.blog-posts li a:visited {
-    color: #8b6fcb;
+    color: #8839ef;
   }
 
   .pubdate-list {
@@ -766,7 +766,7 @@
   #search-input:focus {
     outline: none;
     border-color: var(--link-color);
-    box-shadow: 0 0 0 3px rgba(50, 115, 220, 0.15);
+    box-shadow: 0 0 0 3px rgba(30, 102, 245, 0.15);
   }
 
   #search-input::placeholder {
@@ -836,7 +836,7 @@
   }
 
   .search-result mark {
-    background-color: rgba(255, 220, 0, 0.4);
+    background-color: rgba(223, 142, 29, 0.4);
     color: inherit;
     padding: 1px 2px;
     border-radius: 2px;

--- a/static/theme.css
+++ b/static/theme.css
@@ -1,6 +1,7 @@
 :root {
-  --color-gray: #888;
-  --color-grayer: #666;
+  /* Catppuccin Latte grays */
+  --color-gray: #8c8fa1;
+  --color-grayer: #6c6f85;
 
   --font-title:
     "Inter", "Fira Sans", "Lato", system-ui, -apple-system,
@@ -15,14 +16,14 @@
     "Fira Code", "PT Mono", "IBM Plex Mono", Menlo, Consolas, Monaco,
     "Liberation Mono", "Ubuntu Mono", "Lucida Console", monospace;
 
-  /* Color palette */
-  --color-light-bg: #fffcf0;
-  --color-light-text: #444;
-  --color-light-heading: #222;
-  --color-light-link: #3273dc;
-  --color-light-border: #ddd;
-  --color-light-code-bg: #f5f5f5;
-  --color-light-code-text: #1a1a1a;
+  /* Catppuccin Latte light palette */
+  --color-light-bg: #eff1f5;
+  --color-light-text: #4c4f69;
+  --color-light-heading: #4c4f69;
+  --color-light-link: #1e66f5;
+  --color-light-border: #ccd0da;
+  --color-light-code-bg: #e6e9ef;
+  --color-light-code-text: #4c4f69;
 
   --color-dark-bg: #19150f;
   --color-dark-text: #dddddd;
@@ -113,14 +114,14 @@ content img {
 }
 
 .old-entry-warning {
-  border-left: 5px solid #ff8a34;
-  background-color: orange;
+  border-left: 5px solid #fe640b;
+  background-color: #fe640b;
   padding: 1rem 1.15rem;
   margin: 1.75rem 0;
   font-size: 1em;
   border-radius: 6px;
   font-weight: 500;
-  color: #222;
+  color: #eff1f5;
   box-shadow: 0 4px 18px rgba(0, 0, 0, 0.08);
 }
 


### PR DESCRIPTION
Replace the custom warm cream light theme with the Catppuccin Latte color palette for a more consistent, well-designed appearance.

Colors updated:
- Background: #fffcf0 → #eff1f5 (Base)
- Text/Headings: #444/#222 → #4c4f69 (Text)
- Links: #3273dc → #1e66f5 (Blue)
- Visited links: #8b6fcb → #8839ef (Mauve)
- Borders: #ddd → #ccd0da (Surface0)
- Code background: #f5f5f5 → #e6e9ef (Mantle)
- Grays: #888/#666 → #8c8fa1/#6c6f85 (Overlay1/Subtext0)
- Warning box: orange → #fe640b (Peach)