### PR TITLE
Add JSON-LD structured data for SEO

### DIFF
--- a/layouts/partials/json-ld.html
+++ b/layouts/partials/json-ld.html
@@ -28,8 +28,12 @@
   "headline": {{ .Title | jsonify }},
   "description": {{ $description | jsonify }},
   "url": {{ .Permalink | jsonify }},
+  {{- if $datePublished }}
   "datePublished": {{ $datePublished | jsonify }},
+  {{- end }}
+  {{- if $dateModified }}
   "dateModified": {{ $dateModified | jsonify }},
+  {{- end }}
   "author": {{ $author | jsonify }},
   "mainEntityOfPage": {
     "@type": "WebPage",

--- a/layouts/partials/json-ld.html
+++ b/layouts/partials/json-ld.html
@@ -12,6 +12,7 @@
 }
 </script>
 {{- else if .IsPage -}}
+{{- $schemaType := cond (eq .Section "posts") "BlogPosting" "Article" -}}
 {{- $datePublished := "" -}}
 {{- $dateModified := "" -}}
 {{- with .Date -}}
@@ -24,7 +25,7 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
-  "@type": "BlogPosting",
+  "@type": {{ $schemaType | jsonify }},
   "headline": {{ .Title | jsonify }},
   "description": {{ $description | jsonify }},
   "url": {{ .Permalink | jsonify }},

--- a/layouts/partials/json-ld.html
+++ b/layouts/partials/json-ld.html
@@ -1,0 +1,43 @@
+{{- $author := dict "@type" "Person" "name" .Site.Params.Author.name "url" .Site.BaseURL -}}
+
+{{- if .IsHome -}}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": {{ .Site.Title | jsonify }},
+  "description": {{ .Site.Params.description | jsonify }},
+  "url": {{ .Site.BaseURL | jsonify }},
+  "author": {{ $author | jsonify }}
+}
+</script>
+{{- else if .IsPage -}}
+{{- $datePublished := "" -}}
+{{- $dateModified := "" -}}
+{{- with .Date -}}
+  {{- $datePublished = .Format "2006-01-02T15:04:05-07:00" -}}
+{{- end -}}
+{{- with .Lastmod -}}
+  {{- $dateModified = .Format "2006-01-02T15:04:05-07:00" -}}
+{{- end -}}
+{{- $description := .Description | default .Summary | plainify | truncate 160 -}}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": {{ .Title | jsonify }},
+  "description": {{ $description | jsonify }},
+  "url": {{ .Permalink | jsonify }},
+  "datePublished": {{ $datePublished | jsonify }},
+  "dateModified": {{ $dateModified | jsonify }},
+  "author": {{ $author | jsonify }},
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": {{ .Permalink | jsonify }}
+  }
+  {{- with .Params.tags -}}
+  ,"keywords": {{ . | jsonify }}
+  {{- end -}}
+}
+</script>
+{{- end -}}

--- a/layouts/partials/seo_tags.html
+++ b/layouts/partials/seo_tags.html
@@ -4,3 +4,4 @@
 
 {{- template "_internal/opengraph.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
+{{- partial "json-ld.html" . -}}


### PR DESCRIPTION
Add schema.org structured data to improve search engine understanding:
- WebSite schema for homepage
- BlogPosting schema for posts with author, dates, and keywords