### PR TITLE
sort radio stations by name instead of id

### DIFF
--- a/layouts/_default/radio.html
+++ b/layouts/_default/radio.html
@@ -158,19 +158,19 @@
 (function() {
   const stations = [
     // keep-sorted start
-    { id: 'ambient', name: 'SomaFM Drone Zone', genre: 'drone', url: 'https://ice4.somafm.com/dronezone-64-aac', homepage: 'https://somafm.com/dronezone/' },
-    { id: 'beatblender', name: 'SomaFM Beat Blender', genre: 'deep house', url: 'https://ice4.somafm.com/beatblender-64-aac', homepage: 'https://somafm.com/beatblender/' },
-    { id: 'bossa', name: 'SomaFM Bossa Beyond', genre: 'bossa nova', url: 'https://ice4.somafm.com/bossa-64-aac', homepage: 'https://somafm.com/bossa/' },
-    { id: 'deepspaceone', name: 'SomaFM Deep Space One', genre: 'space', url: 'https://ice4.somafm.com/deepspaceone-64-aac', homepage: 'https://somafm.com/deepspaceone/' },
-    { id: 'defcon', name: 'SomaFM DEF CON Radio', genre: 'hacking', url: 'https://ice4.somafm.com/defcon-64-aac', homepage: 'https://somafm.com/defcon/', starred: true },
-    { id: 'groovesalad', name: 'SomaFM Groove Salad', genre: 'downtempo', url: 'https://ice4.somafm.com/groovesalad-64-aac', homepage: 'https://somafm.com/groovesalad/' },
-    { id: 'indie', name: 'SomaFM Indie Pop Rocks', genre: 'pop', url: 'https://ice4.somafm.com/indiepop-64-aac', homepage: 'https://somafm.com/indiepop/' },
-    { id: 'jazz', name: 'SomaFM Jazz', genre: 'jazz', url: 'https://ice4.somafm.com/live-64-aac', homepage: 'https://somafm.com/live/' },
-    { id: 'kfai', name: 'KFAI Minneapolis', genre: 'community', url: 'https://kfai.broadcasttool.stream/kfai-1', homepage: 'https://www.kfai.org/' },
-    { id: 'lofi', name: 'Lo-fi Hip Hop', genre: 'hip hop', url: 'https://live.hunter.fm/lofi_low', homepage: 'https://hunter.fm/' },
-    { id: 'nightride', name: 'Nightride FM', genre: 'synthwave', url: 'https://stream.nightride.fm/nightride.ogg', homepage: 'https://nightride.fm/' },
-    { id: 'salsa', name: 'Latina Salsa', genre: 'latin', url: 'https://latinasalsa.ice.infomaniak.ch/latinasalsa.mp3', homepage: 'https://www.radio.net/s/latinasalsa' },
-    { id: 'spacestation', name: 'SomaFM Space Station', genre: 'electronica', url: 'https://ice4.somafm.com/spacestation-64-aac', homepage: 'https://somafm.com/spacestation/' },
+    { name: 'KFAI Minneapolis', id: 'kfai', genre: 'community', url: 'https://kfai.broadcasttool.stream/kfai-1', homepage: 'https://www.kfai.org/' },
+    { name: 'Latina Salsa', id: 'salsa', genre: 'latin', url: 'https://latinasalsa.ice.infomaniak.ch/latinasalsa.mp3', homepage: 'https://www.radio.net/s/latinasalsa' },
+    { name: 'Lo-fi Hip Hop', id: 'lofi', genre: 'hip hop', url: 'https://live.hunter.fm/lofi_low', homepage: 'https://hunter.fm/' },
+    { name: 'Nightride FM', id: 'nightride', genre: 'synthwave', url: 'https://stream.nightride.fm/nightride.ogg', homepage: 'https://nightride.fm/' },
+    { name: 'SomaFM Beat Blender', id: 'beatblender', genre: 'deep house', url: 'https://ice4.somafm.com/beatblender-64-aac', homepage: 'https://somafm.com/beatblender/' },
+    { name: 'SomaFM Bossa Beyond', id: 'bossa', genre: 'bossa nova', url: 'https://ice4.somafm.com/bossa-64-aac', homepage: 'https://somafm.com/bossa/' },
+    { name: 'SomaFM DEF CON Radio', id: 'defcon', genre: 'hacking', url: 'https://ice4.somafm.com/defcon-64-aac', homepage: 'https://somafm.com/defcon/', starred: true },
+    { name: 'SomaFM Deep Space One', id: 'deepspaceone', genre: 'space', url: 'https://ice4.somafm.com/deepspaceone-64-aac', homepage: 'https://somafm.com/deepspaceone/' },
+    { name: 'SomaFM Drone Zone', id: 'ambient', genre: 'drone', url: 'https://ice4.somafm.com/dronezone-64-aac', homepage: 'https://somafm.com/dronezone/' },
+    { name: 'SomaFM Groove Salad', id: 'groovesalad', genre: 'downtempo', url: 'https://ice4.somafm.com/groovesalad-64-aac', homepage: 'https://somafm.com/groovesalad/' },
+    { name: 'SomaFM Indie Pop Rocks', id: 'indie', genre: 'pop', url: 'https://ice4.somafm.com/indiepop-64-aac', homepage: 'https://somafm.com/indiepop/' },
+    { name: 'SomaFM Jazz', id: 'jazz', genre: 'jazz', url: 'https://ice4.somafm.com/live-64-aac', homepage: 'https://somafm.com/live/' },
+    { name: 'SomaFM Space Station', id: 'spacestation', genre: 'electronica', url: 'https://ice4.somafm.com/spacestation-64-aac', homepage: 'https://somafm.com/spacestation/' },
     // keep-sorted end
   ];
 


### PR DESCRIPTION
Move the `name` property to the first position in each station object
so the existing keep-sorted directive enforces alphabetical order by
display name rather than internal id.

https://claude.ai/code/session_01GSEipJJYkFHfWS9thZEZza