### PR TITLE
delete status tag from blog posts

### DIFF
--- a/content/posts/2013-12-31-wordpress-feed.md
+++ b/content/posts/2013-12-31-wordpress-feed.md
@@ -3,7 +3,6 @@ title: "Wordpress Feed"
 date: 2013-12-31T13:09:38+00:00
 tags:
  - legacy
- - status
 ---
 
 Yesterday I discovered a little feature from Wordpress. Head to


### PR DESCRIPTION
Remove the unused "status" tag from 2013-12-31-wordpress-feed.md.

https://claude.ai/code/session_018fwF8yfwnNRLi4Gdfe6cga