### PR TITLE
fix duplicate related posts for page bundle posts

### DIFF
--- a/ci/precompute_links.py
+++ b/ci/precompute_links.py
@@ -102,7 +102,11 @@ def parse_post(file_path: Path) -> dict | None:
         return None
 
     # Get filename without extension as ID
-    post_id = file_path.stem
+    # For page bundles (index.md), use parent directory name to avoid ID collisions
+    if file_path.name == "index.md":
+        post_id = file_path.parent.name
+    else:
+        post_id = file_path.stem
 
     # Parse date (normalize to naive datetime for comparison)
     date_str = frontmatter.get("date", "")


### PR DESCRIPTION
Page bundles (posts using index.md) all got the same post ID "index"
from file_path.stem, causing ID collisions. This led to duplicate
entries in the related posts section (e.g. on /2025/11/radio/).

Use the parent directory name as the ID for page bundles instead.

https://claude.ai/code/session_01DXQAkGvGuPXkvJPmzm9hBE