### PR TITLE
add image-rendering: pixelated to footer badges

### DIFF
--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -474,6 +474,7 @@
     align-items: center;
     gap: 12px;
     flex-wrap: wrap;
+    image-rendering: pixelated;
   }
 
   .badge-wrapper a {


### PR DESCRIPTION
Makes the 88x31 pixel art badges render with crisp edges instead of blurry interpolation.

https://claude.ai/code/session_01NTgR2cxQTWxWQLtzY1DTi2