### PR TITLE
fix: add category links to RSS description footer

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -98,6 +98,15 @@ The only diff is `.Content` instead of `.Summary` for full-text RSS feeds.
         {{- end }}
         {{- $content = print $content (delimit $tagLinks " ") }}
       {{- end }}
+      {{- $hasCategories := gt (len (.GetTerms "categories")) 0 }}
+      {{- if $hasCategories }}
+        {{- if $hasTags }}{{- $content = print $content " " }}{{- end }}
+        {{- $catLinks := slice }}
+        {{- range $cat := (.GetTerms "categories") }}
+          {{- $catLinks = $catLinks | append (printf `<a href="%scategories/%s/">%%%s</a>` (strings.TrimSuffix site.BaseURL "/") (lower $cat.Name) $cat.Name) }}
+        {{- end }}
+        {{- $content = print $content (delimit $catLinks " ") }}
+      {{- end }}
       {{- $content = print $content `</p>` }}
       <description>{{ $content | transform.XMLEscape | safeHTML }}</description>
     </item>


### PR DESCRIPTION
Categories (e.g. %commentary) were missing from the description
footer; only tag links (#tagname) were shown.

https://claude.ai/code/session_01LvMKdaUyb7sR8B7KbQMFsU