### PR TITLE
fix: remove trailing slashes from void elements in HTML templates

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,25 +3,25 @@
 
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="light dark">
   <meta name="theme-color" content="#eff1f5" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#1e1e2e" media="(prefers-color-scheme: dark)">
   <title class="title">{{- block "title" . }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{- end }}</title>
 
   {{- partial "seo_tags.html" . -}}
-  <meta name="referrer" content="no-referrer-when-downgrade" />
+  <meta name="referrer" content="no-referrer-when-downgrade">
 
   {{- with .Site.Params.favicon }}
-  <link rel="icon" href="{{ . | absURL }}" />
+  <link rel="icon" href="{{ . | absURL }}">
   {{- end }}
 
   {{- with .OutputFormats.Get "rss" -}}
   {{ printf `
-  <link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+  <link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
   {{ end -}}
 
-  <link rel="canonical" href="{{ .Permalink }}" />
+  <link rel="canonical" href="{{ .Permalink }}">
 
   {{- with .OutputFormats.Get "Markdown" -}}
   <link rel="alternate" type="text/markdown" href="{{ .Permalink }}" title="{{ $.Title }}">
@@ -40,12 +40,12 @@
     <span class="p-nickname">{{ .Site.Params.Author.nickname }}</span>
     {{- $email := partial "obfuscated-email.html" . -}}
     <a class="u-email" {{ printf `href="mailto:%s"` $email | safeHTMLAttr }}>{{ $email | safeHTML }}</a>
-    <img class="u-photo" src="{{ "thiagowfx.webp" | absURL }}" alt="{{ .Site.Params.Author.name }}" />
+    <img class="u-photo" src="{{ "thiagowfx.webp" | absURL }}" alt="{{ .Site.Params.Author.name }}">
   </div>
   <header>
     <div class="header-top">
       <a href="{{ "" | relURL }}" class="title">
-        <img src='{{ "thiagowfx.webp" | absURL }}' alt="thiagowfx's avatar" width="32" height="32" fetchpriority="high" />
+        <img src='{{ "thiagowfx.webp" | absURL }}' alt="thiagowfx's avatar" width="32" height="32" fetchpriority="high">
         <h1 class="title">{{ .Site.Title }}</h1>
       </a>
       <div class="header-buttons">
@@ -85,7 +85,7 @@
   <main>
     {{- block "main" . }}{{- end }}
   </main>
-  <hr />
+  <hr>
   <footer>
     <span>
       {{ site.Copyright | markdownify }} · <a href="{{ "canary" | relURL }}">🐦</a> · <a href="https://uptime.perrotta.dev/status/indianapolis">status</a>
@@ -143,28 +143,28 @@
 
     <div class="badge-wrapper">
       <a target="_blank" href="https://creativecommons.org/licenses/by-nc-sa/4.0/" title="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License">
-        <img src="{{ "vendor/cc-by-nc-sa-4.0-88x31.webp" | absURL }}" width="88" height="31" alt="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License" loading="lazy" />
+        <img src="{{ "vendor/cc-by-nc-sa-4.0-88x31.webp" | absURL }}" width="88" height="31" alt="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License" loading="lazy">
       </a>
       <a target="_blank" href="https://indieweb.org/" title="IndieWebCamp">
-        <img src="{{ "vendor/indieweb88x31-flat.webp" | absURL }}" width="88" height="31" alt="IndieWebCamp" loading="lazy" />
+        <img src="{{ "vendor/indieweb88x31-flat.webp" | absURL }}" width="88" height="31" alt="IndieWebCamp" loading="lazy">
       </a>
       <a target="_blank" href="https://512kb.club" title="512kb.club badge">
-        <img src="{{ "vendor/green-team.webp" | absURL }}" width="88" height="31" alt="a proud member of the green team of 512KB club" loading="lazy" />
+        <img src="{{ "vendor/green-team.webp" | absURL }}" width="88" height="31" alt="a proud member of the green team of 512KB club" loading="lazy">
       </a>
       <a target="_blank" href="https://powrss.com/" title="powRSS">
-        <img src="{{ "vendor/powrss-88-31.webp" | absURL }}" width="88" height="31" alt="powRSS" loading="lazy" />
+        <img src="{{ "vendor/powrss-88-31.webp" | absURL }}" width="88" height="31" alt="powRSS" loading="lazy">
       </a>
       <a target="_blank" href="https://www.vim.org/" title="Vim text editor">
-        <img src="{{ "vendor/vim.webp" | absURL }}" width="88" height="31" alt="Vim text editor" loading="lazy" />
+        <img src="{{ "vendor/vim.webp" | absURL }}" width="88" height="31" alt="Vim text editor" loading="lazy">
       </a>
       <a target="_blank" href="https://edleeman.co.uk/cookie-zero/" title="Cookie Zero">
-        <img src="{{ "vendor/cookiezero.webp" | absURL }}" width="88" height="31" alt="Cookie Zero" loading="lazy" />
+        <img src="{{ "vendor/cookiezero.webp" | absURL }}" width="88" height="31" alt="Cookie Zero" loading="lazy">
       </a>
       <a target="_blank" href="{{ printf "https://validator.w3.org/nu/?doc=%s" .Site.BaseURL }}" title="Valid HTML5">
-        <img src="{{ "vendor/html5-validator-badge.webp" | absURL }}" width="88" height="31" alt="Valid HTML5" loading="lazy" />
+        <img src="{{ "vendor/html5-validator-badge.webp" | absURL }}" width="88" height="31" alt="Valid HTML5" loading="lazy">
       </a>
       <a target="_blank" href="{{ printf "https://validator.w3.org/feed/check.cgi?url=%s" ("index.xml" | absURL) }}" title="Valid RSS feed">
-        <img src="{{ "vendor/valid-rss-rogers.webp" | absURL }}" width="88" height="31" alt="Valid RSS feed" loading="lazy" />
+        <img src="{{ "vendor/valid-rss-rogers.webp" | absURL }}" width="88" height="31" alt="Valid RSS feed" loading="lazy">
       </a>
     </div>
 

--- a/layouts/partials/search-modal.html
+++ b/layouts/partials/search-modal.html
@@ -2,7 +2,7 @@
   <div class="search-modal-backdrop"></div>
   <div class="search-modal-container">
     <div class="search-modal-header">
-      <input type="text" id="search-modal-input" placeholder="{{ i18n "searchPlaceholder" }}" autocomplete="off" />
+      <input type="text" id="search-modal-input" placeholder="{{ i18n "searchPlaceholder" }}" autocomplete="off">
       <kbd class="search-modal-kbd">ESC</kbd>
     </div>
     <div id="search-modal-info" class="search-info"></div>

--- a/layouts/partials/search-widget.html
+++ b/layouts/partials/search-widget.html
@@ -5,7 +5,7 @@
 {{- $excludeCategories := .excludeCategories | default slice }}
 {{- $includeCategories := .includeCategories | default slice }}
 <div class="search-container">
-  <input type="text" id="search-input" placeholder="{{ i18n "searchPlaceholder" }}" autocomplete="off" {{ if $autofocus }}autofocus{{ end }} />
+  <input type="text" id="search-input" placeholder="{{ i18n "searchPlaceholder" }}" autocomplete="off" {{ if $autofocus }}autofocus{{ end }}>
   <div id="search-info" class="search-info"></div>
 </div>
 <div id="search-results" class="search-results"></div>

--- a/layouts/partials/seo_tags.html
+++ b/layouts/partials/seo_tags.html
@@ -1,6 +1,6 @@
-<meta name="title" content="{{ with .Title }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}" />
-<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary | plainify | truncate 160 }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
-<meta name="keywords" content="{{ if .IsPage}}{{ range $index, $tag := .Params.tags }}{{ $tag }},{{ end }}{{ else }}{{ range $plural, $terms := .Site.Taxonomies }}{{ range $term, $val := $terms }}{{ printf "%s," $term }}{{ end }}{{ end }}{{ end }}" />
+<meta name="title" content="{{ with .Title }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}">
+<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary | plainify | truncate 160 }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
+<meta name="keywords" content="{{ if .IsPage}}{{ range $index, $tag := .Params.tags }}{{ $tag }},{{ end }}{{ else }}{{ range $plural, $terms := .Site.Taxonomies }}{{ range $term, $val := $terms }}{{ printf "%s," $term }}{{ end }}{{ end }}{{ end }}">
 
 {{- template "_internal/opengraph.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}


### PR DESCRIPTION
Trailing slashes on void elements (meta, link, img, hr, input) have no
effect in HTML5 and interact badly with unquoted attribute values. Remove
them to pass W3C HTML validator without info warnings.

https://claude.ai/code/session_014s1G14RHuNM3XJxDJ8qfVo