### PR TITLE
fix: match "written by human" badge size to other footer badges

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -167,7 +167,7 @@
         <img src="{{ "vendor/valid-rss-rogers.webp" | absURL }}" width="88" height="31" alt="Valid RSS feed" loading="lazy">
       </a>
       <a href="{{ "/ai" | relURL }}" title="Written by a Human, Not by AI">
-        <img src="{{ "vendor/written-by-human-not-by-ai.svg" | absURL }}" width="131" height="42" alt="Written by a Human, Not by AI" loading="lazy" />
+        <img src="{{ "vendor/written-by-human-not-by-ai.svg" | absURL }}" width="88" height="31" alt="Written by a Human, Not by AI" loading="lazy">
       </a>
     </div>
 


### PR DESCRIPTION
Resize from 131x42 to 88x31 to be consistent with all other footer badges.
Also remove trailing slash from void img element for consistency.

https://claude.ai/code/session_011h3ggjKe52ez5A2BDRE55S