### PR TITLE
fix broken multi-file configs link in prek post

### DIFF
--- a/content/posts/2026-04-20-migrating-from-pre-commit-to-prek.md
+++ b/content/posts/2026-04-20-migrating-from-pre-commit-to-prek.md
@@ -47,7 +47,7 @@ runs, the difference is smaller but still noticeable.
 Two other niceties `pre-commit` does not have:
 
 - **Split configs across multiple files**. `prek` supports
-  [multi-file configs](https://prek.j178.dev/config/#multiple-configs), so
+  [multi-file configs](https://prek.j178.dev/workspace/), so
   hooks can live next to the subproject they belong to in a monorepo instead
   of piling up in a single top-level YAML.
 - **Run against a commit or a range**. `prek run --from-ref A --to-ref B`


### PR DESCRIPTION
The old URL (prek.j178.dev/config/#multiple-configs) 404s; the docs
moved to the Workspace Mode page.