### PR TITLE
Remove 'review' tag from 2013 retrospective post

### DIFF
--- a/content/pt/posts/2013-12-29-retrospectiva-2013-blablabla.md
+++ b/content/pt/posts/2013-12-29-retrospectiva-2013-blablabla.md
@@ -6,7 +6,6 @@ tags:
   - dev
   - legacy
   - meta
-  - review
 ---
 
 Esse post é bem mais específico do que o título pode deixar a entender. Já


### PR DESCRIPTION
## Summary
Removed the 'review' tag from the 2013 retrospective blog post metadata.

## Changes
- Removed `review` tag from the front matter of the 2013-12-29 retrospective post

## Details
This appears to be a cleanup of post metadata, removing an unnecessary or outdated tag classification from the retrospective article.

https://claude.ai/code/session_01Fn3tC52wTJTvqP8vwHmXRf