### PR TITLE
Remove animation from theme toggle button

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -34,11 +34,6 @@ document.getElementById("theme-toggle").addEventListener("click", function () {
   const cycle = { auto: "light", light: "dark", dark: "auto" };
   const next = cycle[current];
   setTheme(next);
-
-  // Animate the icon
-  const button = this;
-  button.classList.add("spinning");
-  setTimeout(() => button.classList.remove("spinning"), 600);
 });
 
 // Dropdown menu functionality

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -440,15 +440,6 @@
     transform: translateY(-2px);
   }
 
-  @keyframes spin {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
-    }
-  }
-
   #theme-toggle {
     background: none;
     border: none;
@@ -458,10 +449,6 @@
     display: inline-block;
     vertical-align: middle;
     transition: transform 0.2s ease;
-  }
-
-  #theme-toggle.spinning {
-    animation: spin 0.6s ease-in-out;
   }
 
   #theme-toggle:active {


### PR DESCRIPTION
The theme toggle icon no longer spins when clicked. This simplifies the interaction by removing the 360-degree rotation animation and the associated JavaScript event handler.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011DyGx14i1Uza9RQG7VQNgN